### PR TITLE
Fix pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>br.upe</groupId>
   <artifactId>projeto-programacao-3</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
 
   <name>Projeto de Programação 3</name>
 


### PR DESCRIPTION
The packaging option in the pom.xml file has been fixed to define jar as the packaging for the project instead of pom.