### PR TITLE
Update cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,9 @@
 name: Continuous Deployment
 
 on:
-    push:
-      branches:
-        - release
+  push:
+    tags:
+      - v*
 
 jobs:
   build:
@@ -50,13 +50,13 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ matrix.os }} Development Build
+          name: Release ${{ github.ref_name }} (${{ matrix.os }})
+          tag_name: ${{ github.ref_name }}
           draft: false
           prerelease: false
           fail_on_unmatched_files: false
           make_latest: true
           generate_release_notes: false
-          target_commitish: release
           token: ${{ secrets.GITHUB_TOKEN}}
           files: |
             ./target/*.msi


### PR DESCRIPTION
The trigger event configuration of the continuous deployment workflow has been updated. The workflow is now triggered when a new version tag is pushed to the repository. The configuration of the softprops/action-gh-release@v2 action has also been updated to work with the new configuration.